### PR TITLE
Update token endpoint response to match working standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"**/*.ts\""
   },
   "dependencies": {
+    "@livekit/protocol": "^1.41.0",
     "body-parser": "^2.2.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"**/*.ts\""
   },
   "dependencies": {
+    "body-parser": "^2.2.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "livekit-server-sdk": "^2.8.1"
@@ -19,6 +20,7 @@
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.13.0",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.0",
     "@types/node": "^22.8.6",
     "@typescript-eslint/eslint-plugin": "^8.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@livekit/protocol':
+        specifier: ^1.41.0
+        version: 1.41.0
       body-parser:
         specifier: ^2.2.0
         version: 2.2.0
@@ -183,8 +186,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/protocol@1.36.1':
-    resolution: {integrity: sha512-nN3QnITAQ5yXk7UKfotH7CRWIlEozNWeKVyFJ0/+dtSzvWP/ib+10l1DDnRYi3A1yICJOGAKFgJ5d6kmi1HCUA==}
+  '@livekit/protocol@1.41.0':
+    resolution: {integrity: sha512-bozBB39VSbd0IjRBwShMlLskqkd9weWJNskaB1CVpcEO9UUI1gMwAtBJOKYblzZJT9kE1SJa3L4oWWwsZMzSXw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1649,7 +1652,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/protocol@1.36.1':
+  '@livekit/protocol@1.41.0':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      body-parser:
+        specifier: ^2.2.0
+        version: 2.2.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -27,6 +30,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
         version: 4.3.0(prettier@3.3.3)
+      '@types/body-parser':
+        specifier: ^1.19.6
+        version: 1.19.6
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.1
@@ -208,8 +214,8 @@ packages:
       '@vue/compiler-sfc':
         optional: true
 
-  '@types/body-parser@1.19.5':
-    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -388,6 +394,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -856,6 +866,14 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1032,6 +1050,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
@@ -1051,8 +1073,16 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -1192,6 +1222,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1206,6 +1240,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.1:
+    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
+    engines: {node: '>= 0.10'}
 
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
@@ -1387,6 +1425,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.2:
@@ -1639,7 +1681,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@types/body-parser@1.19.5':
+  '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 22.13.13
@@ -1657,7 +1699,7 @@ snapshots:
 
   '@types/express@5.0.1':
     dependencies:
-      '@types/body-parser': 1.19.5
+      '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.0.6
       '@types/serve-static': 1.15.7
 
@@ -1895,6 +1937,20 @@ snapshots:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.1
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2482,6 +2538,14 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -2615,7 +2679,7 @@ snapshots:
   livekit-server-sdk@2.11.0:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@livekit/protocol': 1.36.1
+      '@livekit/protocol': 1.41.0
       camelcase-keys: 9.1.3
       jose: 5.10.0
 
@@ -2633,6 +2697,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   merge-descriptors@1.0.3: {}
 
   merge2@1.4.1: {}
@@ -2646,9 +2712,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -2768,6 +2840,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   quick-lru@6.1.2: {}
@@ -2779,6 +2855,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.1:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
       unpipe: 1.0.0
 
   regexp.prototype.flags@1.5.3:
@@ -2987,6 +3070,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
 
   typed-array-buffer@1.0.2:
     dependencies:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,23 +1,35 @@
+import { RoomConfiguration } from '@livekit/protocol';
+import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import express from 'express';
-import bodyParser from 'body-parser';
 import { AccessToken } from 'livekit-server-sdk';
 
 type TokenRequest = {
-  roomName: string;
-  participantName: string;
+  roomName?: string;
+  participantName?: string;
+
+  room_name?: string;
+  participant_name?: string;
+  participant_identity?: string;
+  participant_metadata?: string;
+  participant_attributes?: Record<string, string>;
+  room_config?: ReturnType<RoomConfiguration['toJson']>;
 };
 
 // Load environment variables from .env.local file
 dotenv.config({ path: '.env.local' });
 
 // This route handler creates a token for a given room and participant
-async function createToken({ roomName, participantName }: TokenRequest) {
+async function createToken(request: TokenRequest) {
+  const roomName = request.room_name ?? request.roomName!;
+  const participantName = request.participant_name ?? request.participantName!;
+
   const at = new AccessToken(process.env.LIVEKIT_API_KEY, process.env.LIVEKIT_API_SECRET, {
     identity: participantName,
     // Token to expire after 10 minutes
     ttl: '10m',
   });
+
   // Token permissions can be added here based on the
   // desired capabilities of the participant
   at.addGrant({
@@ -25,6 +37,20 @@ async function createToken({ roomName, participantName }: TokenRequest) {
     room: roomName,
     canUpdateOwnMetadata: true,
   });
+
+  if (request.participant_identity) {
+    at.identity = request.participant_identity;
+  }
+  if (request.participant_metadata) {
+    at.metadata = request.participant_metadata;
+  }
+  if (request.participant_attributes) {
+    at.attributes = request.participant_attributes;
+  }
+  if (request.room_config) {
+    at.roomConfig = RoomConfiguration.fromJson(request.room_config);
+  }
+
   return at.toJwt();
 }
 
@@ -33,8 +59,19 @@ app.use(bodyParser.json());
 const port = 3000;
 
 app.post('/createToken', async (req, res) => {
-  const { roomName = 'demo-room', participantName = 'demo-user' } = req.body ?? {};
-  res.send(await createToken({ roomName, participantName }));
+  const body = req.body ?? {};
+  body.roomName = body.roomName ?? 'demo-room';
+  body.participantName = body.participantName ?? 'demo-user';
+
+  try {
+    res.send({
+      server_url: process.env.LIVEKIT_URL,
+      participant_token: await createToken(body),
+    });
+  } catch (err) {
+    console.error('Error generating token:', err);
+    res.status(500).send({ message: 'Generating token failed' });
+  }
 });
 
 app.listen(port, () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,15 +5,16 @@ import express from 'express';
 import { AccessToken } from 'livekit-server-sdk';
 
 type TokenRequest = {
-  roomName?: string;
-  participantName?: string;
-
   room_name?: string;
   participant_name?: string;
   participant_identity?: string;
   participant_metadata?: string;
   participant_attributes?: Record<string, string>;
   room_config?: ReturnType<RoomConfiguration['toJson']>;
+
+  // (old fields, here for backwards compatibility)
+  roomName?: string;
+  participantName?: string;
 };
 
 // Load environment variables from .env.local file

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,8 +61,8 @@ const port = 3000;
 
 app.post('/createToken', async (req, res) => {
   const body = req.body ?? {};
-  body.roomName = body.roomName ?? 'demo-room';
-  body.participantName = body.participantName ?? 'demo-user';
+  body.roomName = body.roomName ?? `room-${crypto.randomUUID()}`;
+  body.participantName = body.participantName ?? `user-${crypto.randomUUID()}`;
 
   try {
     res.send({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import express from 'express';
+import bodyParser from 'body-parser';
 import { AccessToken } from 'livekit-server-sdk';
 
 type TokenRequest = {
@@ -28,6 +29,7 @@ async function createToken({ roomName, participantName }: TokenRequest) {
 }
 
 const app = express();
+app.use(bodyParser.json());
 const port = 3000;
 
 app.post('/createToken', async (req, res) => {


### PR DESCRIPTION
As part of the [TokenSource change](https://github.com/livekit/client-sdk-js/pull/1645), update the token server example to accept a request / receive a response that matches the standard that has been discussed as part of that change.

Namely, a few important details:
- Make request / response body `snake_case` not `camelCase` - since this is an example, I made a breaking api change to the endpoint response, which I am assuming is fine. Previously the endpoint was just returning a string token though (ie, no wrapper object to rename fields within) so I don't really see an alternative unfortunately.
- Add new `participant_identity` / `participant_metadata` / `participant_attributes` / `room_config` request fields
- Add new `server_url` / `participant_token` fields to the response